### PR TITLE
Player verification

### DIFF
--- a/src/ImAMadDev/CountdownMaster.php
+++ b/src/ImAMadDev/CountdownMaster.php
@@ -16,6 +16,7 @@ use pocketmine\event\player\PlayerCommandPreprocessEvent;
 use pocketmine\event\player\PlayerItemConsumeEvent;
 use pocketmine\event\player\PlayerItemUseEvent;
 use pocketmine\event\player\PlayerJoinEvent;
+use pocketmine\player\Player;
 use pocketmine\plugin\PluginBase;
 use pocketmine\utils\TextFormat;
 
@@ -140,6 +141,7 @@ class CountdownMaster extends PluginBase implements Listener{
     public function onEntityDamage(EntityDamageEvent $event) : void
     {
         if ($event->isCancelled()) return;
+        if (!$event->getEntity() instanceof Player) return;
         foreach (CountdownManager::getInstance()->getCountdownByEvent(get_class($event)) as $countdown) {
             if ($this->getSession($event->getEntity()->getName())?->hasCountdown($countdown->getName())){
                 if ($countdown->isCancelEvent()) {


### PR DESCRIPTION
The verification is not done, so if the identity is a mob or any other identity that does not have the `getName()`, `sendMessage()` function, it will give an error.
In addition, these functions are only fulfilled to players